### PR TITLE
Adding error handling

### DIFF
--- a/Plugin/Quote/Item/AttributesToOrderItem.php
+++ b/Plugin/Quote/Item/AttributesToOrderItem.php
@@ -52,6 +52,10 @@ class AttributesToOrderItem
             $children = $quoteItem->getChildren();
             $childItem = current($children);
 
+            if ($childItem === false) {
+                return '';
+            }
+            
             $value = $childItem->getProduct() ? (string)$childItem->getProduct()->getData($attributeCode) : '';
             if ($value) {
                 return $value;


### PR DESCRIPTION
We track more and more errors in sentry where `$childItem` is false and therefore the following code in `readAttribute()` is going to fail with `Call to a member function getProduct() on bool `. I didn't debug the whole stack trace yet. Nevertheless, the `current` function can return a bool and therefore the code afterwards won't succeed. 

Would appreciate a quick merge.